### PR TITLE
Replaced delegate method

### DIFF
--- a/test/ViewController.swift
+++ b/test/ViewController.swift
@@ -67,7 +67,7 @@ extension ViewController: UICollectionViewDataSource {
 //MARK: - CUSTOMIZING COLLECTION VIEW FLOW LAYOUT
 extension ViewController: UICollectionViewDelegateFlowLayout {
   
-  func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAtIndex section: Int) -> CGFloat {
+  func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
     return self.spaceBetweenCells
   }
   


### PR DESCRIPTION
Replaced collectionView(:_layout:minimumInterimSpacingForSectionAt:) to collectionView(:_layout:minimumLineSpacingForSectionAt:).
Seems like `minimumInterimSpacingForSectionAt` does not really work as desired. When I changed the `spaceBetweenCells` to be higher, the cells were not centered anymore. Using `minimumLineSpacingForSectionAt` fixed it for me.